### PR TITLE
Compile tests

### DIFF
--- a/include/asio/ssl/dtls/socket.hpp
+++ b/include/asio/ssl/dtls/socket.hpp
@@ -45,7 +45,6 @@
 namespace asio {
 namespace ssl  {
 namespace dtls {
-
 /// Provides Datagram-oriented functionality using SSL.
 /**
  * The dtls class template provides asynchronous and blocking stream-oriented

--- a/src/examples/server/main.cpp
+++ b/src/examples/server/main.cpp
@@ -120,11 +120,12 @@ private:
         }
     }
 
-    void encrypted_data_sent(const asio::error_code &ec, dtls_sock_ptr)
+    void encrypted_data_sent(const asio::error_code &ec, dtls_sock_ptr socket)
     {
         if(!ec)
         {
             std::cout << "Data sent, closing connection." << std::endl;
+            socket->async_shutdown([socket](const asio::error_code&){});
         }
     }
 

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(compile)
 add_subdirectory(executors)

--- a/src/tests/unit/compile/CMakeLists.txt
+++ b/src/tests/unit/compile/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(test_compile STATIC compile.cpp)
+target_link_libraries(test_compile asio_dtls)

--- a/src/tests/unit/compile/compile.cpp
+++ b/src/tests/unit/compile/compile.cpp
@@ -1,0 +1,67 @@
+#include <array>
+#include <asio/ip/udp.hpp>
+#include <asio/ssl/dtls/socket.hpp>
+
+// These checks make sure using the classes compile. They are no
+// example for proper usage.
+void socket()
+{
+    asio::io_context ctx;
+    asio::ssl::dtls::context dtls_ctx(asio::ssl::dtls::context::dtls_client);
+    asio::error_code ec;
+    std::array<char, 1> buffer_data{0};
+    asio::mutable_buffer mbuffer(buffer_data.data(), buffer_data.size());
+    asio::const_buffer buffer(buffer_data.data(), buffer_data.size());
+
+    asio::ssl::dtls::socket<asio::ip::udp::socket> dtls_socket(ctx, dtls_ctx);
+    dtls_socket.get_executor();
+    dtls_socket.get_io_context();
+    dtls_socket.get_io_service();
+
+    dtls_socket.handshake(asio::ssl::stream_base::client);
+    dtls_socket.handshake(asio::ssl::stream_base::client, ec);
+    dtls_socket.handshake(asio::ssl::stream_base::client, buffer);
+    dtls_socket.handshake(asio::ssl::stream_base::client, buffer, ec);
+
+    dtls_socket.lowest_layer();
+    dtls_socket.native_handle();
+    dtls_socket.set_cookie_verify_callback([](const std::string &, const asio::ip::udp::endpoint&){return true;});
+    dtls_socket.set_cookie_verify_callback([](const std::string &, const asio::ip::udp::endpoint&){return true;}, ec);
+
+    dtls_socket.set_mtu(500);
+    dtls_socket.set_mtu(500, ec);
+
+    dtls_socket.set_verify_depth(0);
+    dtls_socket.set_verify_depth(0, ec);
+
+    dtls_socket.set_verify_mode(asio::ssl::verify_none);
+    dtls_socket.set_verify_mode(asio::ssl::verify_none, ec);
+
+    dtls_socket.shutdown();
+    dtls_socket.shutdown(ec);
+
+    dtls_socket.async_handshake(asio::ssl::stream_base::client,
+                                [](const asio::error_code &){});
+    dtls_socket.async_handshake(asio::ssl::stream_base::client, buffer,
+                                [](const asio::error_code &, size_t){});
+
+    dtls_socket.async_receive(mbuffer, [](const asio::error_code &, size_t){});
+
+    dtls_socket.async_send(buffer, [](const asio::error_code &, size_t){});
+
+    dtls_socket.async_shutdown([](const asio::error_code&){});
+
+    dtls_socket.next_layer();
+
+    dtls_socket.receive(mbuffer);
+    dtls_socket.receive(mbuffer, ec);
+
+    dtls_socket.send(buffer);
+    dtls_socket.send(buffer, ec);
+
+    dtls_socket.set_cookie_generate_callback([](std::string &, const asio::ip::udp::endpoint&){return true;});
+    dtls_socket.set_cookie_generate_callback([](std::string &, const asio::ip::udp::endpoint&){return true;}, ec);
+
+    asio::ip::udp::socket s(ctx);
+    dtls_socket.verify_cookie(s, buffer, ec, asio::ip::udp::endpoint{});
+}

--- a/src/tests/unit/compile/compile.cpp
+++ b/src/tests/unit/compile/compile.cpp
@@ -1,6 +1,9 @@
 #include <array>
 #include <asio/ip/udp.hpp>
+#include <asio/ssl/dtls/acceptor.hpp>
 #include <asio/ssl/dtls/socket.hpp>
+
+#include <asio/ip/tcp.hpp>
 
 // These checks make sure using the classes compile. They are no
 // example for proper usage.
@@ -64,4 +67,69 @@ void socket()
 
     asio::ip::udp::socket s(ctx);
     dtls_socket.verify_cookie(s, buffer, ec, asio::ip::udp::endpoint{});
+}
+
+// These checks make sure using a strand compiles. They are no
+// example for proper usage.
+void acceptor()
+{
+    asio::io_context ctx;
+    asio::ssl::dtls::context dtls_ctx(asio::ssl::dtls::context::dtls_client);
+    asio::error_code ec;
+    std::array<char, 1> buffer_data{0};
+    asio::mutable_buffer mbuffer(buffer_data.data(), buffer_data.size());
+    asio::const_buffer buffer(buffer_data.data(), buffer_data.size());
+    asio::ip::udp::endpoint ep;
+    asio::ssl::dtls::socket<asio::ip::udp::socket> dtls_socket(ctx, dtls_ctx);
+
+    asio::ssl::dtls::acceptor<asio::ip::udp::socket> acc(ctx, ep);
+
+    acc.bind(ep);
+    acc.bind(ep, ec);
+
+    acc.cancel();
+    acc.cancel(ec);
+
+    acc.close();
+    acc.close(ec);
+
+    acc.get_service();
+
+    acc.open(ep.protocol());
+    acc.open(ep.protocol(), ec);
+
+    acc.accept(dtls_socket, mbuffer);
+
+    acc.async_accept(dtls_socket, mbuffer, [](const asio::error_code&, size_t){}, ec);
+
+    asio::ip::udp::socket::reuse_address option;
+    acc.get_option(option);
+    acc.get_option(option, ec);
+
+    acc.set_option(option);
+    acc.set_option(option, ec);
+
+    asio::detail::io_control::bytes_readable command;
+    acc.io_control(command);
+    acc.io_control(command, ec);
+
+    acc.local_endpoint();
+    acc.local_endpoint(ec);
+
+    acc.native_non_blocking();
+    acc.native_non_blocking(true);
+    acc.native_non_blocking(true, ec);
+
+    acc.non_blocking();
+    acc.non_blocking(true);
+    acc.non_blocking(true, ec);
+
+    acc.set_cookie_generate_callback(
+       [](std::string &, const asio::ip::udp::endpoint&){return true;});
+
+    acc.set_cookie_verify_callback(
+       [](const std::string&, const asio::ip::udp::endpoint&){return true;});
+
+    acc.set_option(asio::socket_base::reuse_address(true));
+    acc.set_option(asio::socket_base::reuse_address(true), ec);
 }


### PR DESCRIPTION
Add Compile tests for
- asio::ssl::dtls::socket
- asio::ssl::dtls::acceptor

These tests make sure the Methods compile,
no guarantees they do what they're supposed to
do.